### PR TITLE
Added Markdown from jnovack.github.com/pear/Markdown

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,8 +93,8 @@ on your machine:
   $ pear channel-discover zustellzentrum.cweiske.de
   $ pear install zz/mime_type_plaindetect-alpha
 
-  $ pear channel-discover pear.michelf.ca
-  $ pear install michelf/Markdown
+  $ pear channel-discover jnovack.github.com/pear
+  $ pear install jnovack/Markdown
 
 Note that this version of GeSHi is a bit outdated, but it's the fastest
 way to install it.

--- a/src/phorkie/Renderer/Markdown.php
+++ b/src/phorkie/Renderer/Markdown.php
@@ -15,8 +15,9 @@ class Renderer_Markdown
     {
         /**
          */
-        require_once 'markdown.php';
-        $markdown = \markdown($file->getContent());
+        require_once 'Markdown.php';
+        $md = new \Markdown;
+        $markdown = $md->parse($file->getContent());
 
         return '<div class="markdown">'
             . $markdown

--- a/src/phorkie/SetupCheck.php
+++ b/src/phorkie/SetupCheck.php
@@ -11,6 +11,7 @@ class SetupCheck
         'pear.php.net/Pager'               => 'Pager',
         'pear.php.net/Services_Libravatar' => 'Services_Libravatar',
         'zustellzentrum.cweiske.de/MIME_Type_PlainDetect' => 'MIME_Type_PlainDetect',
+        'jnovack.github.com/pear/Markdown' => 'Markdown',
     );
 
     protected $writableDirs;


### PR DESCRIPTION
Markdown was revamped by Filipe Dobreira (https://github.com/filp/Markdown) to be PHP 5.3.0 complaint with object-orientation goodness.

I had since:
- made the code more PEAR complaint (cosmetic changes only)
- added in HTML5 level elements from pull requests made to https://github.com/michelf/PHP-Markdown
- upgraded the underling base from 1.0.1n to 1.0.1o

I created my own github pear repository to host the PEAR repo, and installed it.

This now permits setup checking properly.

This branch is running at phorkie.ozmonet.com
