### PR TITLE
Add perPage settings into config

### DIFF
--- a/data/config.php.dist
+++ b/data/config.php.dist
@@ -6,6 +6,8 @@
 //$GLOBALS['phorkie']['cfg']['git']['private'] = 'ssh://git@bogo:paste/';
 //$GLOBALS['phorkie']['cfg']['elasticsearch'] = 'http://localhost:9200/phorkie/';
 //$GLOBALS['phorkie']['cfg']['setupcheck'] = false;
+//$GLOBALS['phorkie']['cfg']['listPerPage'] = 10;
+//$GLOBALS['phorkie']['cfg']['searchPerPage'] = 10;
 
 //$GLOBALS['phorkie']['auth']['securityLevel'] = 0;
 //$GLOBALS['phorkie']['auth']['listedUsersOnly'] = false;

--- a/www/list.php
+++ b/www/list.php
@@ -15,7 +15,7 @@ if (isset($_GET['page'])) {
     $page = (int)$_GET['page'] - 1;
 }
 
-$perPage = 10;
+$perPage = $GLOBALS['phorkie']['cfg']['listPerPage'];
 list($repos, $repoCount) = $rs->getList($page, $perPage);
 
 $pager = new Html_Pager(

--- a/www/search.php
+++ b/www/search.php
@@ -20,7 +20,7 @@ if (isset($_GET['page'])) {
     //PEAR Pager begins at 1
     $page = (int)$_GET['page'] - 1;
 }
-$perPage = 10;
+$perPage = $GLOBALS['phorkie']['cfg']['searchPerPage'];
 
 $db     = new Database();
 $search = $db->getSearch();


### PR DESCRIPTION
Moved the perPage settings under `list.php` and `search.php` to `config.php.dist`.

Raison d'être: I wanted to display more results and thought it was silly for users to have to hunt into the code to complete.
