### PR TITLE
Pear install OpenID

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,10 @@ on your machine:
 
   $ pear channel-discover pear.michelf.ca
   $ pear install michelf/Markdown
+  
+  $ pear config-set preferred_state alpha
+  $ pear install OpenID
+  $ pear config-set preferred_state stable
 
 Note that this version of GeSHi is a bit outdated, but it's the fastest
 way to install it.


### PR DESCRIPTION
Add command for Pear to alpha, install OpenID, then set back to stable.

http://pear.php.net/package/OpenID/download/

Current release is in alpha with other deps.  On a clean install Ubuntu 12.04 I got the error saying OpenID wasn't installed ... figured I would throw this in there for anybody that isn't familiar
