### PR TITLE
Avoid mixed content warnings by letting Libravatar detect HTTPS connection

### DIFF
--- a/src/phorkie/HtmlHelper.php
+++ b/src/phorkie/HtmlHelper.php
@@ -10,6 +10,7 @@ class HtmlHelper
         }
 
         $s = new \Services_Libravatar();
+        $s->detectHttps();
         return $s->url(
             $email,
             array(


### PR DESCRIPTION
If Phorkie is served on a HTTPS connection, then the avatar will be too.
